### PR TITLE
Improve Efficiency and Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,20 @@ Parse strings like foo."bar.baz".quux into [ 'foo', 'bar.baz', 'quux' ]
 function parse(string $path) : array
 ```
 
-Parse a given dot notation path into it's parts
+Parse a given dot notation path into it's parts  
+  
+The path is expected to be a string of dot separated keys, where keys can be  
+quoted with double quotes. Backslashes are used to escape double quotes inside  
+quoted keys.  
+
+##### Examples
+
+- `'foo.bar.baz'` => `[ 'foo', 'bar', 'baz' ]`  
+- `'foo."bar.baz"'` => `[ 'foo', 'bar.baz' ]`  
+- `'foo."bar.baz".quux'` => `[ 'foo', 'bar.baz', 'quux' ]`  
+- `'foo."bar\"baz".quux'` => `[ 'foo', 'bar"baz', 'quux' ]`
+
+**Throws**: `\Quorum\DotNotation\Exceptions\ParseException`
 
 ##### Returns:
 

--- a/src/DotNotationParser.php
+++ b/src/DotNotationParser.php
@@ -14,6 +14,18 @@ class DotNotationParser {
 	/**
 	 * Parse a given dot notation path into it's parts
 	 *
+	 * The path is expected to be a string of dot separated keys, where keys can be
+	 * quoted with double quotes. Backslashes are used to escape double quotes inside
+	 * quoted keys.
+	 *
+	 * Examples:
+	 *
+	 * - `'foo.bar.baz'` => `[ 'foo', 'bar', 'baz' ]`
+	 * - `'foo."bar.baz"'` => `[ 'foo', 'bar.baz' ]`
+	 * - `'foo."bar.baz".quux'` => `[ 'foo', 'bar.baz', 'quux' ]`
+	 * - `'foo."bar\"baz".quux'` => `[ 'foo', 'bar"baz', 'quux' ]`
+	 *
+	 * @throws ParseException
 	 * @return string[]
 	 */
 	public function parse( string $path ) : array {
@@ -70,7 +82,7 @@ class DotNotationParser {
 		$buff = '';
 
 		$chars->next();
-		$lastKey = 0;
+		$lastKey = $chars->key();
 		for( ; ; ) {
 			$token = $chars->current();
 			$key   = $chars->key();
@@ -98,6 +110,16 @@ class DotNotationParser {
 					$nextKey ?? $key,
 					ParseException::CODE_UNEXPECTED_CHARACTER
 				);
+			}
+
+			if( $token === '\\' ) {
+				$chars->next();
+				$token = $chars->current();
+				$key   = $chars->key();
+
+				if( !$chars->valid() ) {
+					continue;
+				}
 			}
 
 			$buff .= $token;

--- a/src/Exceptions/ParseException.php
+++ b/src/Exceptions/ParseException.php
@@ -7,9 +7,12 @@ class ParseException extends \InvalidArgumentException {
 	public const CODE_UNEXPECTED_CHARACTER = 22;
 	public const CODE_UNEXPECTED_EOF       = 484;
 
+	/**
+	 * @var int The index of the character that caused the exception
+	 */
 	private $charIndex;
 
-	public function __construct( $message, int $charIndex, $code, ?\Throwable $previous = null ) {
+	public function __construct( string $message, int $charIndex, int $code, ?\Throwable $previous = null ) {
 		parent::__construct($message, $code, $previous);
 
 		$this->charIndex = $charIndex;

--- a/test/Quorum/DotNotation/DotNotationParserTest.php
+++ b/test/Quorum/DotNotation/DotNotationParserTest.php
@@ -20,16 +20,17 @@ class DotNotationParserTest extends TestCase {
 		);
 	}
 
-	public function parseProvider() : \Generator {
-		yield [ 'foo.bar.baz', [ 'foo', 'bar', 'baz' ] ];
-
-		yield [ 'foo."bar.baz"', [ 'foo', 'bar.baz' ] ];
-
-		yield [ 'foo.bar"baz".2', [ 'foo', 'bar"baz"', '2' ] ];
-
-		yield [ 'foo.bar.baz.', [ 'foo', 'bar', 'baz' ] ];
-
-		yield [ '日.本.語', [ '日', '本', '語' ] ];
+	public static function parseProvider() : array {
+		return [
+			[ '', [] ],
+			[ 'foo.bar.baz', [ 'foo', 'bar', 'baz' ] ],
+			[ 'foo."bar.baz"', [ 'foo', 'bar.baz' ] ],
+			[ 'foo.bar"baz".2', [ 'foo', 'bar"baz"', '2' ] ],
+			[ 'foo.bar.baz.', [ 'foo', 'bar', 'baz' ] ],
+			[ '日.本.語', [ '日', '本', '語' ] ],
+			[ 'foo."bar\\"baz".quux', [ 'foo', 'bar"baz', 'quux' ] ],
+			[ 'foo."bar\\\\baz".quux.', [ 'foo', 'bar\\baz', 'quux' ] ],
+		];
 	}
 
 	/**
@@ -48,14 +49,17 @@ class DotNotationParserTest extends TestCase {
 		$this->fail(sprintf('"%s" failed to throw exception', $path));
 	}
 
-	public function unexpectedCharacterProvider() : \Generator {
-		yield [ 'foo."bar', 8 ];
-
-		yield [ 'a.foo."bar"baz', 11 ];
-
-		yield [ '.foo', 0 ];
-
-		yield [ '.', 0 ];
+	public static function unexpectedCharacterProvider() : array {
+		return [
+			[ 'foo."bar', 8 ],
+			[ 'a.foo."bar"baz', 11 ],
+			[ '.foo', 0 ],
+			[ '.', 0 ],
+			[ 'foo."👨‍👩‍👧‍👦"."broke', 38 ],
+			[ 'a..', 2 ],
+			[ 'a..b', 2 ],
+			[ 'a."\\', 4 ],
+		];
 	}
 
 }


### PR DESCRIPTION
This optimizes the parser by iterating one _grapheme_ at a time rather than exploding into _runes_. The real difference is negligible on small sets, but it's a little better.

The _bigger_ fix here is this adds escaping quotes ala `'foo."bar\"baz"` => `[ 'foo', 'bar"baz' ]`